### PR TITLE
fix: force CI to freeze yarn lockfile

### DIFF
--- a/ci/node-lint.yml
+++ b/ci/node-lint.yml
@@ -13,7 +13,7 @@ jobs:
                   node-version: 12.x
 
             - name: Install
-              run: yarn install
+              run: yarn install --frozen-lockfile
 
             - name: Lint
               run: |

--- a/ci/node-publish.yml
+++ b/ci/node-publish.yml
@@ -16,7 +16,7 @@ jobs:
                   node-version: 12.x
 
             - name: Install
-              run: yarn install
+              run: yarn install --frozen-lockfile
 
             # Customize these as needed
             - name: Test

--- a/ci/node-test.yml
+++ b/ci/node-test.yml
@@ -13,7 +13,7 @@ jobs:
                   node-version: 12.x
 
             - name: Install
-              run: yarn install
+              run: yarn install --frozen-lockfile
 
             - name: Test
               run: yarn test


### PR DESCRIPTION
Running `yarn install` does not respect the local lock-file, since it can overwrite it if there's a version mismatch somewhere.  Running `yarn install --frozen-lockfile`.  This is a bit of a [misconfiguration](https://github.com/yarnpkg/yarn/issues/4147) of `yarn`'s defaults, in my opinion, but we should at least do the right thing in CI