### PR TITLE
fix: remove superfluous e2e dependency and lib-build download

### DIFF
--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -101,7 +101,7 @@ jobs:
     #e2e:
     #    runs-on: ubuntu-latest
     #    if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    #    needs: [install, build]
+    #    needs: [install]
     #
     #    strategy:
     #        matrix:
@@ -120,10 +120,6 @@ jobs:
     #          with:
     #              path: '**/node_modules'
     #              key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-    #
-    #        - uses: actions/download-artifact@v2
-    #          with:
-    #              name: lib-build
     #
     #        - name: Install Cypress binary
     #          run: yarn cypress install


### PR DESCRIPTION
e2e shouldn't nee `build`, and `lib-build` artifact doesn't exist for apps