### PR TITLE
fix: generate translations before running tests

### DIFF
--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -95,6 +95,10 @@ jobs:
                   path: '**/node_modules'
                   key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
 
+            # Can be removed if translations aren't required for tests, or if not using the App Platform
+            - name: Generate translations
+              run: yarn d2-app-scripts i18n generate
+
             - name: Test
               run: yarn test
 


### PR DESCRIPTION
Sometimes tests try to import the generated `locales` directory, which doesn't exist until `build` or `start` is run.  Instead, we can manually generate the translations before running the tests.

This is a temporary fix until we add i18n generation to the platform's test command.