### PR TITLE
chore: set D2_VERBOSE to ensure verbose output from all d2 cli commands

### DIFF
--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -1,8 +1,6 @@
 name: 'dhis2: verify (app)'
 
-on:
-    push:
-        branches:
+on: push
 
 env:
     GIT_AUTHOR_NAME: '@dhis2-bot'
@@ -11,6 +9,7 @@ env:
     GIT_COMMITTER_EMAIL: 'apps@dhis2.org'
     GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
     CI: true
+    D2_VERBOSE: true
 
 jobs:
     install:

--- a/ci/dhis2-verify-lib.yml
+++ b/ci/dhis2-verify-lib.yml
@@ -1,8 +1,6 @@
 name: 'dhis2: verify (lib)'
 
-on:
-    push:
-        branches:
+on: push
 
 env:
     GIT_AUTHOR_NAME: '@dhis2-bot'
@@ -12,6 +10,7 @@ env:
     NPM_TOKEN: ${{secrets.DHIS2_BOT_NPM_TOKEN}}
     GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
     CI: true
+    D2_VERBOSE: true
 
 jobs:
     install:


### PR DESCRIPTION
This updates the template workflows to set the `D2_VERBOSE` env var, which ensures that all d2 cli commands (most notably platform build) will dump verbose output, making for easier failure debugging

This also fixes a lint issue in the workflow yml which would trip up prettier