### PR TITLE
chore: turn off verbose logging for d2

### DIFF
--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -9,7 +9,7 @@ env:
     GIT_COMMITTER_EMAIL: 'apps@dhis2.org'
     GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
     CI: true
-    D2_VERBOSE: true
+    D2_VERBOSE: false
 
 jobs:
     install:

--- a/ci/dhis2-verify-lib.yml
+++ b/ci/dhis2-verify-lib.yml
@@ -10,7 +10,7 @@ env:
     NPM_TOKEN: ${{secrets.DHIS2_BOT_NPM_TOKEN}}
     GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
     CI: true
-    D2_VERBOSE: true
+    D2_VERBOSE: false
 
 jobs:
     install:


### PR DESCRIPTION
I see verbose logging was enabled in this commit: https://github.com/dhis2/workflows/commit/61485ac3ff9f0791295f477f2de9f7f78fd02245 by @amcgee. In this PR: https://github.com/dhis2/scheduler-app/pull/174, @varl and I were talking about this. My note there was:

> The debug info that's being logged is drowning out the linting messages on CI: https://github.com/dhis2/scheduler-app/runs/2381877024?check_suite_focus=true#step:6:121 (this kind of disincentivizes checking the linting errors/warnings, and pushes you towards just ignoring everything that's being logged).

To me the verbose logging is too noisy to be useful in every scenario and it kind out disincentivizes me from checking the logging there. Would it work for you to enable verbose logging whenever necessary, and then have us set the default to off here?