### PR TITLE
chore: skip publish and release for forks and dependabot

### DIFF
--- a/ci/cypress.yml
+++ b/ci/cypress.yml
@@ -17,7 +17,6 @@ env:
 jobs:
     e2e:
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         strategy:
             matrix:
                 containers: [1, 2, 3]

--- a/ci/dhis2-artifacts.yml
+++ b/ci/dhis2-artifacts.yml
@@ -8,7 +8,6 @@ env:
 jobs:
     publish:
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
               with:

--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -14,7 +14,6 @@ env:
 jobs:
     install:
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
         steps:
             - uses: actions/checkout@v2
@@ -35,7 +34,6 @@ jobs:
     build:
         runs-on: ubuntu-latest
         needs: install
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
@@ -62,7 +60,6 @@ jobs:
     lint:
         runs-on: ubuntu-latest
         needs: install
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
@@ -81,7 +78,6 @@ jobs:
     test:
         runs-on: ubuntu-latest
         needs: install
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
@@ -103,7 +99,7 @@ jobs:
 
     #e2e:
     #    runs-on: ubuntu-latest
-    #    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    #    if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
     #    needs: [install]
     #
     #    strategy:
@@ -149,7 +145,7 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         needs: [build, lint, test] # add e2e if you use it
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
+        if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2
               with:
@@ -173,7 +169,7 @@ jobs:
     release:
         runs-on: ubuntu-latest
         needs: [publish]
-        if: "github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]')"
+        if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2
               with:

--- a/ci/dhis2-verify-lib.yml
+++ b/ci/dhis2-verify-lib.yml
@@ -15,7 +15,6 @@ env:
 jobs:
     install:
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
         steps:
             - uses: actions/checkout@v2
@@ -36,7 +35,6 @@ jobs:
     build:
         runs-on: ubuntu-latest
         needs: install
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
@@ -63,7 +61,6 @@ jobs:
     lint:
         runs-on: ubuntu-latest
         needs: install
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
@@ -82,7 +79,6 @@ jobs:
     test:
         runs-on: ubuntu-latest
         needs: [install, build]
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
@@ -100,7 +96,6 @@ jobs:
 
     #e2e:
     #    runs-on: ubuntu-latest
-    #    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     #    needs: [install, build]
     #
     #    strategy:
@@ -150,7 +145,6 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         needs: [build, lint, test] # add e2e if in use
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
               with:

--- a/ci/dhis2-verify-lib.yml
+++ b/ci/dhis2-verify-lib.yml
@@ -96,6 +96,7 @@ jobs:
 
     #e2e:
     #    runs-on: ubuntu-latest
+    #    if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
     #    needs: [install, build]
     #
     #    strategy:
@@ -145,6 +146,7 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         needs: [build, lint, test] # add e2e if in use
+        if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2
               with:

--- a/ci/dhis2-verify-node.yml
+++ b/ci/dhis2-verify-node.yml
@@ -16,7 +16,6 @@ env:
 jobs:
     install:
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
         steps:
             - uses: actions/checkout@v2
@@ -37,7 +36,6 @@ jobs:
     lint:
         runs-on: ubuntu-latest
         needs: install
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
@@ -56,7 +54,6 @@ jobs:
     test:
         runs-on: ubuntu-latest
         needs: install
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
@@ -75,7 +72,6 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         needs: [install, lint, test]
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
               with:

--- a/ci/dhis2-verify-node.yml
+++ b/ci/dhis2-verify-node.yml
@@ -72,6 +72,7 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         needs: [install, lint, test]
+        if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2
               with:

--- a/ci/docker-publish.yml
+++ b/ci/docker-publish.yml
@@ -25,7 +25,6 @@ jobs:
     test:
         runs-on: ubuntu-latest
 
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
         steps:
             - uses: actions/checkout@v2
@@ -46,7 +45,7 @@ jobs:
 
         runs-on: ubuntu-latest
 
-        if: github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]')
+        if: github.event_name == 'push'
 
         steps:
             - uses: actions/checkout@v2

--- a/ci/node-lint.yml
+++ b/ci/node-lint.yml
@@ -5,7 +5,6 @@ on: push
 jobs:
     check:
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1

--- a/ci/node-publish.yml
+++ b/ci/node-publish.yml
@@ -25,7 +25,6 @@ env:
 jobs:
     publish:
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
               with:

--- a/ci/node-test.yml
+++ b/ci/node-test.yml
@@ -5,7 +5,6 @@ on: push
 jobs:
     unit:
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1


### PR DESCRIPTION
Skip steps that need secrets for forks and dependabot PRs. Currently we try to run these steps for dependabot and outside PRs as well, which causes CI to fail as GH doesn't expose secrets to those kinds of PRs.

Also the manual skip ci check is no longer necessary, so I removed it ([https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/](https://github.blog/changelog/2021-02-08-github-actions-skip-pull-request-and-push-workflows-with-skip-ci/)).