### PR TITLE
chore: generate cypress id to fix cypress retries failing

### DIFF
--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -97,10 +97,20 @@ jobs:
             - name: Test
               run: yarn test
 
+    #cypress_id:
+    #    runs-on: ubuntu-latest
+    #    outputs:
+    #        ci_build_id: ${{ steps.ci_build_id.outputs.value }}
+    #
+    #    steps:
+    #        - name: Generate cypress build id
+    #          id: ci_build_id
+    #          run: echo "::set-output name=value::$GITHUB_SHA-$(date +"%s")"
+    #
     #e2e:
     #    runs-on: ubuntu-latest
     #    if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
-    #    needs: [install]
+    #    needs: [install, cypress_id]
     #
     #    strategy:
     #        matrix:
@@ -126,6 +136,7 @@ jobs:
     #        - name: End-to-End tests
     #          uses: cypress-io/github-action@v2
     #          with:
+    #              ci-build-id: '${{ needs.cypress_id.outputs.ci_build_id }}'
     #              install: false
     #              record: true
     #              parallel: true

--- a/ci/dhis2-verify-lib.yml
+++ b/ci/dhis2-verify-lib.yml
@@ -94,10 +94,20 @@ jobs:
             - name: Test
               run: yarn test
 
+    #cypress_id:
+    #    runs-on: ubuntu-latest
+    #    outputs:
+    #        ci_build_id: ${{ steps.ci_build_id.outputs.value }}
+    #
+    #    steps:
+    #        - name: Generate cypress build id
+    #          id: ci_build_id
+    #          run: echo "::set-output name=value::$GITHUB_SHA-$(date +"%s")"
+
     #e2e:
     #    runs-on: ubuntu-latest
     #    if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
-    #    needs: [install, build]
+    #    needs: [install, build, cypress_id]
     #
     #    strategy:
     #        matrix:
@@ -127,6 +137,7 @@ jobs:
     #        - name: End-to-End tests
     #          uses: cypress-io/github-action@v2
     #          with:
+    #              ci-build-id: '${{ needs.cypress_id.outputs.ci_build_id }}'
     #              install: false
     #              record: true
     #              parallel: true


### PR DESCRIPTION
https://jira.dhis2.org/browse/CLI-36

Cypress CI runs can't be restarted with our current config (see https://jira.dhis2.org/browse/CLI-36). This fixes that by passing a unique id for each workflow run.