### PR TITLE
ci(cypress): update cypress rerun fix

### DIFF
--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -97,16 +97,6 @@ jobs:
             - name: Test
               run: yarn test
 
-    #cypress_id:
-    #    runs-on: ubuntu-latest
-    #    outputs:
-    #        ci_build_id: ${{ steps.ci_build_id.outputs.value }}
-    #
-    #    steps:
-    #        - name: Generate cypress build id
-    #          id: ci_build_id
-    #          run: echo "::set-output name=value::$GITHUB_SHA-$(date +"%s")"
-    #
     #e2e:
     #    runs-on: ubuntu-latest
     #    if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
@@ -136,7 +126,6 @@ jobs:
     #        - name: End-to-End tests
     #          uses: cypress-io/github-action@v2
     #          with:
-    #              ci-build-id: '${{ needs.cypress_id.outputs.ci_build_id }}'
     #              install: false
     #              record: true
     #              parallel: true
@@ -148,6 +137,7 @@ jobs:
     #              tag: ${{ github.event_name }}
     #          env:
     #              CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+    #              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     #              COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
     #              STORYBOOK_TESTING: true
     #              SERVER_START_CMD: 'yarn cy:server'

--- a/ci/dhis2-verify-lib.yml
+++ b/ci/dhis2-verify-lib.yml
@@ -94,16 +94,6 @@ jobs:
             - name: Test
               run: yarn test
 
-    #cypress_id:
-    #    runs-on: ubuntu-latest
-    #    outputs:
-    #        ci_build_id: ${{ steps.ci_build_id.outputs.value }}
-    #
-    #    steps:
-    #        - name: Generate cypress build id
-    #          id: ci_build_id
-    #          run: echo "::set-output name=value::$GITHUB_SHA-$(date +"%s")"
-
     #e2e:
     #    runs-on: ubuntu-latest
     #    if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
@@ -137,7 +127,6 @@ jobs:
     #        - name: End-to-End tests
     #          uses: cypress-io/github-action@v2
     #          with:
-    #              ci-build-id: '${{ needs.cypress_id.outputs.ci_build_id }}'
     #              install: false
     #              record: true
     #              parallel: true
@@ -149,6 +138,7 @@ jobs:
     #              tag: ${{ github.event_name }}
     #          env:
     #              CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
+    #              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     #              COMMIT_INFO_MESSAGE: ${{ github.event.pull_request.title }}
     #              STORYBOOK_TESTING: true
     #              SERVER_START_CMD: 'yarn cy:server'


### PR DESCRIPTION
I noticed in the cypress action docs that cypress already fixes the rerun issue automatically if you pass it the GITHUB_TOKEN:

```
# Recommended: pass the GitHub token lets this action correctly
# determine the unique run id necessary to re-run the checks
```
> See https://github.com/cypress-io/github-action#parallel

So this fix is a little simpler.