### PR TITLE
ci(caching): use gha-yarn-cache to cache for yarn

### DIFF
--- a/ci/dhis2-preview-pr.yml
+++ b/ci/dhis2-preview-pr.yml
@@ -39,15 +39,8 @@ jobs:
         with:
           node-version: 12.x
 
-      - uses: actions/cache@v2
-        id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-        with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Install
-        if: steps.yarn-cache.outputs.cache-hit != 'true'
-        run: yarn install --frozen-lockfile
+      - uses: c-hive/gha-yarn-cache@v1
+      - run: yarn install --frozen-lockfile
 
       - name: Build
         run: yarn build

--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -12,39 +12,16 @@ env:
     D2_VERBOSE: true
 
 jobs:
-    install:
-        runs-on: ubuntu-latest
-
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 12.x
-
-            - uses: actions/cache@v2
-              id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-              with:
-                  path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-
-            - name: Install
-              if: steps.yarn-cache.outputs.cache-hit != 'true'
-              run: yarn install --frozen-lockfile
-
     build:
         runs-on: ubuntu-latest
-        needs: install
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
                   node-version: 12.x
 
-            - uses: actions/cache@v2
-              id: yarn-cache
-              with:
-                  path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
 
             - name: Build
               run: yarn build
@@ -59,36 +36,28 @@ jobs:
 
     lint:
         runs-on: ubuntu-latest
-        needs: install
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
                   node-version: 12.x
 
-            - uses: actions/cache@v2
-              id: yarn-cache
-              with:
-                  path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
 
             - name: Lint
               run: yarn lint
 
     test:
         runs-on: ubuntu-latest
-        needs: install
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
                   node-version: 12.x
 
-            - uses: actions/cache@v2
-              id: yarn-cache
-              with:
-                  path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
 
             # Can be removed if translations aren't required for tests, or if not using the App Platform
             - name: Generate translations
@@ -110,7 +79,7 @@ jobs:
     #e2e:
     #    runs-on: ubuntu-latest
     #    if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
-    #    needs: [install, cypress_id]
+    #    needs: [cypress_id]
     #
     #    strategy:
     #        matrix:
@@ -124,11 +93,8 @@ jobs:
     #          with:
     #              node-version: 12.x
     #
-    #        - uses: actions/cache@v2
-    #          id: yarn-cache
-    #          with:
-    #              path: '**/node_modules'
-    #              key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    #        - uses: c-hive/gha-yarn-cache@v1
+    #        - run: yarn install --frozen-lockfile
     #
     #        - name: Install Cypress binary
     #          run: yarn cypress install

--- a/ci/dhis2-verify-lib.yml
+++ b/ci/dhis2-verify-lib.yml
@@ -13,39 +13,16 @@ env:
     D2_VERBOSE: true
 
 jobs:
-    install:
-        runs-on: ubuntu-latest
-
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 12.x
-
-            - uses: actions/cache@v2
-              id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-              with:
-                  path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-
-            - name: Install
-              if: steps.yarn-cache.outputs.cache-hit != 'true'
-              run: yarn install --frozen-lockfile
-
     build:
         runs-on: ubuntu-latest
-        needs: install
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
                   node-version: 12.x
 
-            - uses: actions/cache@v2
-              id: yarn-cache
-              with:
-                  path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
 
             - name: Build
               run: yarn build
@@ -60,36 +37,29 @@ jobs:
 
     lint:
         runs-on: ubuntu-latest
-        needs: install
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
                   node-version: 12.x
 
-            - uses: actions/cache@v2
-              id: yarn-cache
-              with:
-                  path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
 
             - name: Lint
               run: yarn lint
 
     test:
         runs-on: ubuntu-latest
-        needs: [install, build]
+        needs: [build]
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
                   node-version: 12.x
 
-            - uses: actions/cache@v2
-              id: yarn-cache
-              with:
-                  path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
 
             - name: Test
               run: yarn test
@@ -121,11 +91,8 @@ jobs:
     #          with:
     #              node-version: 12.x
     #
-    #        - uses: actions/cache@v2
-    #          id: yarn-cache
-    #          with:
-    #              path: '**/node_modules'
-    #              key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+    #        - uses: c-hive/gha-yarn-cache@v1
+    #        - run: yarn install --frozen-lockfile
     #
     #        - uses: actions/download-artifact@v2
     #          with:

--- a/ci/dhis2-verify-node.yml
+++ b/ci/dhis2-verify-node.yml
@@ -14,64 +14,37 @@ env:
     CI: true
 
 jobs:
-    install:
-        runs-on: ubuntu-latest
-
-        steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
-              with:
-                  node-version: 12.x
-
-            - uses: actions/cache@v2
-              id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
-              with:
-                  path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-
-            - name: Install
-              if: steps.yarn-cache.outputs.cache-hit != 'true'
-              run: yarn install --frozen-lockfile
-
     lint:
         runs-on: ubuntu-latest
-        needs: install
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
                   node-version: 12.x
 
-            - uses: actions/cache@v2
-              id: yarn-cache
-              with:
-                  path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
 
             - name: Lint
               run: yarn lint
 
     test:
         runs-on: ubuntu-latest
-        needs: install
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
                   node-version: 12.x
 
-            - uses: actions/cache@v2
-              id: yarn-cache
-              with:
-                  path: '**/node_modules'
-                  key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
 
             - name: Test
               run: yarn test
 
     publish:
         runs-on: ubuntu-latest
-        needs: [install, lint, test]
+        needs: [lint, test]
         if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2
@@ -80,6 +53,9 @@ jobs:
             - uses: actions/setup-node@v1
               with:
                   node-version: 12.x
+
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
 
             - name: Publish to NPM
               run: npx @dhis2/cli-utils release --publish npm

--- a/ci/node-lint.yml
+++ b/ci/node-lint.yml
@@ -11,8 +11,8 @@ jobs:
               with:
                   node-version: 12.x
 
-            - name: Install
-              run: yarn install --frozen-lockfile
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
 
             - name: Run linters
               run: |

--- a/ci/node-publish.yml
+++ b/ci/node-publish.yml
@@ -33,8 +33,8 @@ jobs:
               with:
                   node-version: 12.x
 
-            - name: Install
-              run: yarn install --frozen-lockfile
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
 
             # TODO: Customize these steps as needed
             - name: Build

--- a/ci/node-test.yml
+++ b/ci/node-test.yml
@@ -11,8 +11,8 @@ jobs:
               with:
                   node-version: 12.x
 
-            - name: Install
-              run: yarn install --frozen-lockfile
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
 
             - name: Test
               run: yarn test


### PR DESCRIPTION
This uses https://github.com/c-hive/gha-yarn-cache to cache modules for our yarn installs in the recommended manner. It's a little simpler than our current approach, and also doesn't cache `node_modules`, which isn't recommended (see the linked action's docs).

Added bonus is that we now don't have to have one single job blocking execution of the parallel tasks that come after it (install job is no longer necessary, so lint, build, test, etc. can now all start running in parallel from the start).