### PR TITLE
ci(actions): set concurrency for github actions

### DIFF
--- a/ci/dhis2-preview-pr.yml
+++ b/ci/dhis2-preview-pr.yml
@@ -29,6 +29,10 @@ on:
   pull_request:
     types: [ labeled ]
 
+concurrency:
+    group: ${{ github.workflow}}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -2,6 +2,10 @@ name: 'dhis2: verify (app)'
 
 on: push
 
+concurrency:
+    group: ${{ github.workflow}}-${{ github.ref }}
+    cancel-in-progress: true
+
 env:
     GIT_AUTHOR_NAME: '@dhis2-bot'
     GIT_AUTHOR_EMAIL: 'apps@dhis2.org'

--- a/ci/dhis2-verify-lib.yml
+++ b/ci/dhis2-verify-lib.yml
@@ -2,6 +2,10 @@ name: 'dhis2: verify (lib)'
 
 on: push
 
+concurrency:
+    group: ${{ github.workflow}}-${{ github.ref }}
+    cancel-in-progress: true
+
 env:
     GIT_AUTHOR_NAME: '@dhis2-bot'
     GIT_AUTHOR_EMAIL: 'apps@dhis2.org'

--- a/ci/dhis2-verify-node.yml
+++ b/ci/dhis2-verify-node.yml
@@ -4,6 +4,10 @@ on:
     push:
         branches:
 
+concurrency:
+    group: ${{ github.workflow}}-${{ github.ref }}
+    cancel-in-progress: true
+
 env:
     GIT_AUTHOR_NAME: '@dhis2-bot'
     GIT_AUTHOR_EMAIL: 'apps@dhis2.org'

--- a/ci/node-lint.yml
+++ b/ci/node-lint.yml
@@ -2,6 +2,10 @@ name: 'dhis2: lint (node)'
 
 on: push
 
+concurrency:
+    group: ${{ github.workflow}}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     check:
         runs-on: ubuntu-latest

--- a/ci/node-test.yml
+++ b/ci/node-test.yml
@@ -2,6 +2,10 @@ name: 'dhis2: test (node)'
 
 on: push
 
+concurrency:
+    group: ${{ github.workflow}}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
     unit:
         runs-on: ubuntu-latest


### PR DESCRIPTION
This sets the max concurrency for workflow to 1 run per workflow, per branch, for a couple of our workflows. I've added it where it seemed safe to only run the workflow on the latest commit.

You can see it in action here: https://github.com/dhis2/scheduler-app/pull/218.

It's officially in beta, but if it's good enough for google and wordpress (https://github.com/google/web-stories-wp/issues/7604), then it's probably good enough for us as well.

Closes dhis2/scheduler-app#218