### PR TITLE
fix(release): ensure publishing workflows run sequentially

### DIFF
--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -4,7 +4,6 @@ on: push
 
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}
-    cancel-in-progress: true
 
 env:
     GIT_AUTHOR_NAME: '@dhis2-bot'

--- a/ci/dhis2-verify-lib.yml
+++ b/ci/dhis2-verify-lib.yml
@@ -4,7 +4,6 @@ on: push
 
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}
-    cancel-in-progress: true
 
 env:
     GIT_AUTHOR_NAME: '@dhis2-bot'

--- a/ci/dhis2-verify-node.yml
+++ b/ci/dhis2-verify-node.yml
@@ -6,7 +6,6 @@ on:
 
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}
-    cancel-in-progress: true
 
 env:
     GIT_AUTHOR_NAME: '@dhis2-bot'


### PR DESCRIPTION
Fixes https://github.com/dhis2/notes/discussions/300. It ensures the workflows where I've made the change will only run one of these workflows at a time per branch: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#concurrency. In progress workflows won't be cancelled, so they'll run sequentially.

Maybe eventualy we could have separate workflows for semantic release and non-semantic release branches. We could then configure release branches to run workflows sequentially and everything else can just cancel what's in progress and only run latest.

You can also specify concurrency at the job level: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idconcurrency. But that does not have the guarantee that jobs will run sequentially, so for publishing that could cause issues. Plus publishing does not seem prudent without having linted, tested, etc. first, so it seems hard to use the job level concurrency for this.