### PR TITLE
ci: add commit checking workflows

### DIFF
--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -49,6 +49,8 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
             - uses: actions/setup-node@v1
               with:
                   node-version: 12.x
@@ -63,6 +65,9 @@ jobs:
 
             - name: Lint
               run: yarn d2-style check
+            - uses: wagoid/commitlint-github-action@v4
+              with:
+                configFile: commitlint.config.js
 
     test:
         runs-on: ubuntu-latest

--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -49,8 +49,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-              with:
-                  fetch-depth: 0
             - uses: actions/setup-node@v1
               with:
                   node-version: 12.x
@@ -65,9 +63,20 @@ jobs:
 
             - name: Lint
               run: yarn d2-style check
+
+    commitlint:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
+            - id: commitlint
+              run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")
             - uses: wagoid/commitlint-github-action@v4
               with:
-                configFile: commitlint.config.js
+                  configFile: ${{ steps.commitlint.outputs.config_path }}
 
     test:
         runs-on: ubuntu-latest

--- a/ci/dhis2-verify-lib.yml
+++ b/ci/dhis2-verify-lib.yml
@@ -55,6 +55,20 @@ jobs:
             - name: Lint
               run: yarn d2-style check
 
+    commitlint:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
+            - id: commitlint
+              run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")
+            - uses: wagoid/commitlint-github-action@v4
+              with:
+                  configFile: ${{ steps.commitlint.outputs.config_path }}
+
     test:
         runs-on: ubuntu-latest
         needs: [build]

--- a/ci/dhis2-verify-node.yml
+++ b/ci/dhis2-verify-node.yml
@@ -34,6 +34,20 @@ jobs:
             - name: Lint
               run: yarn d2-style check
 
+    commitlint:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+              with:
+                  fetch-depth: 0
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
+            - id: commitlint
+              run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")
+            - uses: wagoid/commitlint-github-action@v4
+              with:
+                  configFile: ${{ steps.commitlint.outputs.config_path }}
+
     test:
         runs-on: ubuntu-latest
         steps:

--- a/ci/dhis2-verify-pr-title.yml
+++ b/ci/dhis2-verify-pr-title.yml
@@ -1,0 +1,13 @@
+name: 'dhis2: verify (pr title)'
+
+on:
+    pull_request:
+        types: ['opened', 'edited', 'reopened', 'synchronize']
+
+jobs:
+    verify:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - run: yarn install @commitlint/config-conventional
+            - uses: JulienKode/pull-request-name-linter-action@v0.5.0

--- a/ci/dhis2-verify-pr-title.yml
+++ b/ci/dhis2-verify-pr-title.yml
@@ -1,13 +1,18 @@
-name: 'dhis2: verify (pr title)'
+name: 'dhis2: check pr title'
 
 on:
     pull_request:
         types: ['opened', 'edited', 'reopened', 'synchronize']
 
 jobs:
-    verify:
+    commitlint:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - run: yarn install @commitlint/config-conventional
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
+            - id: commitlint
+              run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")
             - uses: JulienKode/pull-request-name-linter-action@v0.5.0
+              with:
+                  configuration-path: ${{ steps.commitlint.outputs.config_path }}


### PR DESCRIPTION
Still a draft, but this adds workflows we could use to lint commits in a PR (and the PR title). See this [thread on slack](https://dhis2.slack.com/archives/CBM8LNEQM/p1650451095049319). The semantic pr check we use is a github app maintained by a single person. If it goes down all our pr commit checks go down (https://github.com/zeke/semantic-pull-requests).

It's not really technically necessary for this to be an app, github actions can do the job as well:

- commit linting: https://github.com/wagoid/commitlint-github-action
- pr title linting: https://github.com/JulienKode/pull-request-name-linter-action

By default we use the semantic pr check to lint the pr title and the commits. See [the template in cli-style](https://github.com/dhis2/cli-style/blob/master/templates/github-semantic.yml). And [this search for semantic.yml in our repos](https://github.com/search?q=org%3Adhis2+filename%3Asemantic.yml&type=Code&ref=advsearch&l=&l=). Some codebases have modified the file.

- Example of the above action-based checks for an app (see the status checks): https://github.com/dhis2/usage-analytics-app/pull/653

The one thing we would need to change is to add a configuration file for commitlint to the root of our projects. `JulienKode/pull-request-name-linter-action` requires it and `wagoid/commitlint-github-action` doesn't technically need it, but otherwise it might get out of sync with our settings. 

With cli-style we do expose commands like `d2-style check commit` and we have [a commitlint config here](https://github.com/dhis2/cli-style/blob/master/config/commitlint.config.js). But I think we have kept that hidden from users for now. I'm not sure if it would be all right for cli-style if we expose this. It's similar to what we've done with eslint for example, for which we now also have config in the root.

### Sidenote

I've only added the commit checking to our `app` workflow. It should be added to a couple other ones as well. Which leads me to this:

- https://github.community/t/depend-on-another-workflow/16311/15
- https://github.blog/changelog/2021-08-25-github-actions-reduce-duplication-with-action-composition/
- https://docs.github.com/en/actions/using-workflows/reusing-workflows

As a followup we might be able to leverage action composition to get rid of (some of) the duplication in our actions.