### PR TITLE
fix: add commitlint job to release needs

### DIFF
--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -133,7 +133,7 @@ jobs:
 
     release:
         runs-on: ubuntu-latest
-        needs: [build, lint, test] # add e2e if you use it
+        needs: [build, lint, commitlint, test] # add e2e if you use it
         if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2

--- a/ci/dhis2-verify-lib.yml
+++ b/ci/dhis2-verify-lib.yml
@@ -125,7 +125,7 @@ jobs:
 
     publish:
         runs-on: ubuntu-latest
-        needs: [build, lint, test] # add e2e if in use
+        needs: [build, lint, commitlint, test] # add e2e if in use
         if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2

--- a/ci/dhis2-verify-node.yml
+++ b/ci/dhis2-verify-node.yml
@@ -64,7 +64,7 @@ jobs:
 
     publish:
         runs-on: ubuntu-latest
-        needs: [lint, test]
+        needs: [lint, commitlint, test]
         if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
This adds commitlint to the steps that are required to succeed before release/publish.