### PR TITLE
ci(netlify): add netlify deploy workflows

### DIFF
--- a/ci/dhis2-netlify-deploy-branch.yml
+++ b/ci/dhis2-netlify-deploy-branch.yml
@@ -23,12 +23,12 @@ jobs:
     deploy:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
               with:
                   node-version: 16.x
+                  cache: yarn
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Build
@@ -36,7 +36,7 @@ jobs:
 
             - name: Deploy
               id: netlify-deploy
-              uses: nwtgck/actions-netlify@v1.2.4
+              uses: nwtgck/actions-netlify@v2
               timeout-minutes: 1
               with:
                   github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}

--- a/ci/dhis2-netlify-deploy-branch.yml
+++ b/ci/dhis2-netlify-deploy-branch.yml
@@ -1,4 +1,4 @@
-name: 'dhis2: pr preview'
+name: 'dhis2: netlify deploy branch'
 
 # Requirements:
 #
@@ -10,21 +10,23 @@ name: 'dhis2: pr preview'
 # - Customize the 'jobs.build.steps.netlify-deploy.publish-dir' property
 
 on:
-    pull_request:
+    push:
+        branches:
+            # add branches that should be deployed here
+            - development
 
 concurrency:
     group: ${{ github.workflow}}-${{ github.ref }}
     cancel-in-progress: true
 
 jobs:
-    preview:
+    deploy:
         runs-on: ubuntu-latest
-        if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
             - uses: actions/checkout@v2
             - uses: actions/setup-node@v1
               with:
-                  node-version: 12.x
+                  node-version: 16.x
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
@@ -34,17 +36,18 @@ jobs:
 
             - name: Deploy
               id: netlify-deploy
-              uses: nwtgck/actions-netlify@v1.2.2
+              uses: nwtgck/actions-netlify@v1.2.4
               timeout-minutes: 1
               with:
                   github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
                   github-deployment-environment: 'netlify'
-                  github-deployment-description: 'PR Preview on Netlify'
-                  deploy-message: ${{ github.event.pull_request.title }}
-                  enable-pull-request-comment: true
+                  github-deployment-description: 'Branch Deploy on Netlify'
+                  deploy-message: Github actions branch deploy
+                  enable-pull-request-comment: false
                   enable-commit-comment: true
                   enable-commit-status: true
-                  alias: pr-${{ github.event.number }}
+                  production-deploy: false
+                  alias: ${{ github.ref_name }}
                   # customize according to project needs
                   publish-dir: 'build/app'
               env:

--- a/ci/dhis2-netlify-deploy-pr.yml
+++ b/ci/dhis2-netlify-deploy-pr.yml
@@ -21,12 +21,12 @@ jobs:
         runs-on: ubuntu-latest
         if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 14.x
+                  node-version: 16.x
+                  cache: yarn
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Build
@@ -34,7 +34,7 @@ jobs:
 
             - name: Deploy
               id: netlify-deploy
-              uses: nwtgck/actions-netlify@v1.2.4
+              uses: nwtgck/actions-netlify@v2
               timeout-minutes: 1
               with:
                   github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}

--- a/ci/dhis2-netlify-deploy-pr.yml
+++ b/ci/dhis2-netlify-deploy-pr.yml
@@ -1,0 +1,54 @@
+name: 'dhis2: netlify deploy pr'
+
+# Requirements:
+#
+# - Org secrets:
+#       DHIS2_BOT_NETLIFY_TOKEN
+#       DHIS2_BOT_GITHUB_TOKEN
+# - Repo secrets:
+#       NETLIFY_SITE_ID
+# - Customize the 'jobs.build.steps.netlify-deploy.publish-dir' property
+
+on:
+    pull_request:
+
+concurrency:
+    group: ${{ github.workflow}}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        if: "!github.event.push.repository.fork && github.actor != 'dependabot[bot]'"
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 14.x
+
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
+
+            - name: Build
+              run: yarn d2-app-scripts build --standalone
+
+            - name: Deploy
+              id: netlify-deploy
+              uses: nwtgck/actions-netlify@v1.2.4
+              timeout-minutes: 1
+              with:
+                  github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
+                  github-deployment-environment: 'netlify'
+                  github-deployment-description: 'PR Preview on Netlify'
+                  deploy-message: ${{ github.event.pull_request.title }}
+                  enable-pull-request-comment: true
+                  enable-commit-comment: true
+                  enable-commit-status: true
+                  alias: pr-${{ github.event.number }}
+                  # customize according to project needs
+                  publish-dir: 'build/app'
+              env:
+                  # org secret
+                  NETLIFY_AUTH_TOKEN: ${{ secrets.DHIS2_BOT_NETLIFY_TOKEN }}
+                  # repo secret
+                  NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/ci/dhis2-netlify-deploy-production.yml
+++ b/ci/dhis2-netlify-deploy-production.yml
@@ -1,0 +1,59 @@
+name: 'dhis2: netlify deploy production'
+
+# Requirements:
+#
+# - Org secrets:
+#       DHIS2_BOT_NETLIFY_TOKEN
+#       DHIS2_BOT_GITHUB_TOKEN
+# - Repo secrets:
+#       NETLIFY_SITE_ID
+# - Customize the 'jobs.build.steps.netlify-deploy.publish-dir' property
+# - Specify the branch that should be deployed as the production deploy (in two locations)
+
+on:
+    push:
+        branches:
+            # 1. specify the production branch here
+            - master
+
+concurrency:
+    group: ${{ github.workflow}}-${{ github.ref }}
+    cancel-in-progress: true
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: 16.x
+
+            - uses: c-hive/gha-yarn-cache@v1
+            - run: yarn install --frozen-lockfile
+
+            - name: Build
+              run: yarn d2-app-scripts build --standalone
+
+            - name: Deploy
+              id: netlify-deploy
+              uses: nwtgck/actions-netlify@v1.2.4
+              timeout-minutes: 1
+              with:
+                  github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
+                  github-deployment-environment: 'netlify'
+                  github-deployment-description: 'Production Deploy on Netlify'
+                  deploy-message: Github actions production deploy
+                  enable-pull-request-comment: false
+                  enable-commit-comment: true
+                  enable-commit-status: true
+                  # 2. and specify the production branch here as well
+                  production-branch: master
+                  production-deploy: true
+                  # customize according to project needs
+                  publish-dir: 'build/app'
+              env:
+                  # org secret
+                  NETLIFY_AUTH_TOKEN: ${{ secrets.DHIS2_BOT_NETLIFY_TOKEN }}
+                  # repo secret
+                  NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/ci/dhis2-netlify-deploy-production.yml
+++ b/ci/dhis2-netlify-deploy-production.yml
@@ -24,12 +24,12 @@ jobs:
     deploy:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/checkout@v3
+            - uses: actions/setup-node@v3
               with:
                   node-version: 16.x
+                  cache: yarn
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Build
@@ -37,7 +37,7 @@ jobs:
 
             - name: Deploy
               id: netlify-deploy
-              uses: nwtgck/actions-netlify@v1.2.4
+              uses: nwtgck/actions-netlify@v2
               timeout-minutes: 1
               with:
                   github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This migrates the netlify deploy workflows that we've been testing in the data entry app (https://github.com/dhis2/aggregate-data-entry-app) to our generic workflows.

I've renamed the dhis2-preview-pr workflow to match the naming scheme of the other workflows, for clarity. This means that anyone migrating to these new workflows will have to remove the old one manually, if it exists. That should not be too big of a deal though, it's just deleting a single file.

- https://dhis2.atlassian.net/browse/LIBS-389
- https://github.com/dhis2/aggregate-data-entry-app/pull/278