### PR TITLE
fix(node): update node 12 to node 16

### DIFF
--- a/ci/dhis2-artifacts.yml
+++ b/ci/dhis2-artifacts.yml
@@ -12,9 +12,9 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   token: ${{env.GH_TOKEN}}
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 12.x
+                  node-version: 16
 
             - uses: dhis2/deploy-build@master
               with:

--- a/ci/dhis2-netlify-deploy-branch.yml
+++ b/ci/dhis2-netlify-deploy-branch.yml
@@ -26,7 +26,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 16.x
+                  node-version: 16
                   cache: yarn
 
             - run: yarn install --frozen-lockfile

--- a/ci/dhis2-netlify-deploy-pr.yml
+++ b/ci/dhis2-netlify-deploy-pr.yml
@@ -24,7 +24,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 16.x
+                  node-version: 16
                   cache: yarn
 
             - run: yarn install --frozen-lockfile

--- a/ci/dhis2-netlify-deploy-production.yml
+++ b/ci/dhis2-netlify-deploy-production.yml
@@ -27,7 +27,7 @@ jobs:
             - uses: actions/checkout@v3
             - uses: actions/setup-node@v3
               with:
-                  node-version: 16.x
+                  node-version: 16
                   cache: yarn
 
             - run: yarn install --frozen-lockfile

--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -27,9 +27,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 12.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
@@ -49,9 +49,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 12.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
@@ -68,9 +68,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 12.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
@@ -96,9 +96,9 @@ jobs:
     #        - name: Checkout
     #          uses: actions/checkout@v2
     #
-    #        - uses: actions/setup-node@v1
+    #        - uses: actions/setup-node@v3
     #          with:
-    #              node-version: 12.x
+    #              node-version: 16
     #
     #        - name: End-to-End tests
     #          uses: cypress-io/github-action@v2
@@ -126,9 +126,9 @@ jobs:
               with:
                   token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
 
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 12.x
+                  node-version: 16
 
             - uses: actions/download-artifact@v2
               with:

--- a/ci/dhis2-verify-lib.yml
+++ b/ci/dhis2-verify-lib.yml
@@ -23,9 +23,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 12.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
@@ -45,9 +45,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 12.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
@@ -60,9 +60,9 @@ jobs:
         needs: [build]
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 12.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
@@ -84,9 +84,9 @@ jobs:
     #        - name: Checkout
     #          uses: actions/checkout@v2
     #
-    #        - uses: actions/setup-node@v1
+    #        - uses: actions/setup-node@v3
     #          with:
-    #              node-version: 12.x
+    #              node-version: 16
     #
     #        - uses: actions/download-artifact@v2
     #          with:
@@ -117,9 +117,9 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   token: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 12.x
+                  node-version: 16
 
             - uses: actions/download-artifact@v2
               with:

--- a/ci/dhis2-verify-node.yml
+++ b/ci/dhis2-verify-node.yml
@@ -24,9 +24,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 12.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
@@ -38,9 +38,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 12.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
@@ -56,9 +56,9 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   token: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 12.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile

--- a/ci/node-lint.yml
+++ b/ci/node-lint.yml
@@ -11,9 +11,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 12.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile

--- a/ci/node-publish.yml
+++ b/ci/node-publish.yml
@@ -29,9 +29,9 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   token: ${{env.GH_TOKEN}}
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 12.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile

--- a/ci/node-test.yml
+++ b/ci/node-test.yml
@@ -11,9 +11,9 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: actions/setup-node@v1
+            - uses: actions/setup-node@v3
               with:
-                  node-version: 12.x
+                  node-version: 16
 
             - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile


### PR DESCRIPTION
As discussed, node 12 is EOL. There are some deprecations in node 18 that we need to address, so node 16 is the most modern version we can update to at the moment.

See https://github.com/dhis2/scheduler-app/pull/453 for a demo of the updates.