### PR TITLE
ci(cache): remove deprecated action

### DIFF
--- a/ci/dhis2-artifacts.yml
+++ b/ci/dhis2-artifacts.yml
@@ -15,6 +15,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - uses: dhis2/deploy-build@master
               with:

--- a/ci/dhis2-netlify-deploy-production.yml
+++ b/ci/dhis2-netlify-deploy-production.yml
@@ -28,7 +28,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
-                  cache: yarn
+                  cache: 'yarn'
 
             - run: yarn install --frozen-lockfile
 

--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -31,7 +31,6 @@ jobs:
               with:
                   node-version: 16
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Build
@@ -53,7 +52,6 @@ jobs:
               with:
                   node-version: 16
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             # Can be removed if translations aren't required for tests,
@@ -72,7 +70,6 @@ jobs:
               with:
                   node-version: 16
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             # Can be removed if translations aren't required for tests,
@@ -135,7 +132,6 @@ jobs:
                   name: app-build
 
             # ensure that d2-app-scripts is available
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - uses: dhis2/action-semantic-release@master

--- a/ci/dhis2-verify-app.yml
+++ b/ci/dhis2-verify-app.yml
@@ -30,6 +30,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - run: yarn install --frozen-lockfile
 
@@ -51,6 +52,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - run: yarn install --frozen-lockfile
 
@@ -69,6 +71,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - run: yarn install --frozen-lockfile
 
@@ -96,6 +99,7 @@ jobs:
     #        - uses: actions/setup-node@v3
     #          with:
     #              node-version: 16
+    #              cache: 'yarn'
     #
     #        - name: End-to-End tests
     #          uses: cypress-io/github-action@v2
@@ -126,6 +130,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - uses: actions/download-artifact@v2
               with:

--- a/ci/dhis2-verify-commits.yml
+++ b/ci/dhis2-verify-commits.yml
@@ -9,7 +9,6 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")
@@ -23,7 +22,6 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   fetch-depth: 0
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")

--- a/ci/dhis2-verify-commits.yml
+++ b/ci/dhis2-verify-commits.yml
@@ -9,6 +9,10 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - uses: actions/checkout@v2
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: 16
+                  cache: 'yarn'
             - run: yarn install --frozen-lockfile
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")
@@ -22,6 +26,10 @@ jobs:
             - uses: actions/checkout@v2
               with:
                   fetch-depth: 0
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: 16
+                  cache: 'yarn'
             - run: yarn install --frozen-lockfile
             - id: commitlint
               run: echo ::set-output name=config_path::$(node -e "process.stdout.write(require('@dhis2/cli-style').config.commitlint)")

--- a/ci/dhis2-verify-lib.yml
+++ b/ci/dhis2-verify-lib.yml
@@ -26,6 +26,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - run: yarn install --frozen-lockfile
 
@@ -47,6 +48,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - run: yarn install --frozen-lockfile
 
@@ -61,6 +63,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - run: yarn install --frozen-lockfile
 
@@ -84,6 +87,7 @@ jobs:
     #        - uses: actions/setup-node@v3
     #          with:
     #              node-version: 16
+    #              cache: 'yarn'
     #
     #        - uses: actions/download-artifact@v2
     #          with:
@@ -117,6 +121,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - uses: actions/download-artifact@v2
               with:

--- a/ci/dhis2-verify-lib.yml
+++ b/ci/dhis2-verify-lib.yml
@@ -27,7 +27,6 @@ jobs:
               with:
                   node-version: 16
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Build
@@ -49,7 +48,6 @@ jobs:
               with:
                   node-version: 16
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Lint
@@ -64,7 +62,6 @@ jobs:
               with:
                   node-version: 16
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Test
@@ -126,7 +123,6 @@ jobs:
                   name: lib-build
 
             # ensure that d2-app-scripts is available
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - uses: dhis2/action-semantic-release@master

--- a/ci/dhis2-verify-node.yml
+++ b/ci/dhis2-verify-node.yml
@@ -28,7 +28,6 @@ jobs:
               with:
                   node-version: 16
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Lint
@@ -42,7 +41,6 @@ jobs:
               with:
                   node-version: 16
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Test
@@ -60,7 +58,6 @@ jobs:
               with:
                   node-version: 16
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - uses: dhis2/action-semantic-release@master

--- a/ci/dhis2-verify-node.yml
+++ b/ci/dhis2-verify-node.yml
@@ -27,6 +27,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - run: yarn install --frozen-lockfile
 
@@ -40,6 +41,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - run: yarn install --frozen-lockfile
 
@@ -57,6 +59,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - run: yarn install --frozen-lockfile
 

--- a/ci/node-lint.yml
+++ b/ci/node-lint.yml
@@ -15,7 +15,6 @@ jobs:
               with:
                   node-version: 16
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Run linters

--- a/ci/node-lint.yml
+++ b/ci/node-lint.yml
@@ -14,6 +14,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - run: yarn install --frozen-lockfile
 

--- a/ci/node-publish.yml
+++ b/ci/node-publish.yml
@@ -33,7 +33,6 @@ jobs:
               with:
                   node-version: 16
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             # TODO: Customize these steps as needed
@@ -47,7 +46,6 @@ jobs:
               run: yarn lint
             # ODOT
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - uses: dhis2/action-semantic-release@master

--- a/ci/node-publish.yml
+++ b/ci/node-publish.yml
@@ -32,6 +32,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - run: yarn install --frozen-lockfile
 

--- a/ci/node-test.yml
+++ b/ci/node-test.yml
@@ -15,7 +15,6 @@ jobs:
               with:
                   node-version: 16
 
-            - uses: c-hive/gha-yarn-cache@v1
             - run: yarn install --frozen-lockfile
 
             - name: Test

--- a/ci/node-test.yml
+++ b/ci/node-test.yml
@@ -14,6 +14,7 @@ jobs:
             - uses: actions/setup-node@v3
               with:
                   node-version: 16
+                  cache: 'yarn'
 
             - run: yarn install --frozen-lockfile
 


### PR DESCRIPTION
See: https://github.com/dhis2/scheduler-app/pull/523. Replaces a deprecated action with the current recommended approach.