### PR TITLE
chore: add analytics-e2e-tests-dev and align with e2e-test workflow

### DIFF
--- a/.github/analytics-e2e-tests-dev.yml
+++ b/.github/analytics-e2e-tests-dev.yml
@@ -1,0 +1,73 @@
+name: 'e2e-dev'
+
+on:
+    workflow_call:
+        secrets:
+            username:
+                required: true
+            password:
+                required: true
+            recordkey:
+                required: true
+
+env:
+    DEV_INSTANCE: https://test.e2e.dhis2.org/analytics-dev
+
+concurrency:
+    group: e2e-dev-${{ github.workflow}}-${{ github.ref }}
+    cancel-in-progress: true
+
+defaults:
+    run:
+        shell: bash
+
+jobs:
+    compute-dev-version:
+        runs-on: ubuntu-latest
+        outputs:
+            version: ${{ steps.instance-version.outputs.version }}
+        steps:
+            - name: Output dev version
+              id: instance-version
+              uses: dhis2/action-instance-version@v1
+              with:
+                  instance-url: ${{ DEV_INSTANCE }}
+                  username: ${{ secrets.username }}
+                  password: ${{ secrets.password }}
+
+    e2e-dev:
+        needs: compute-dev-version
+        runs-on: ubuntu-latest
+
+        strategy:
+            fail-fast: false
+            matrix:
+                containers: [1, 2, 3, 4]
+
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v3
+
+            - uses: actions/setup-node@v3
+              with:
+                  node-version: 18.x
+
+            - name: Run e2e tests
+              uses: cypress-io/github-action@v5
+              with:
+                  start: yarn d2-app-scripts start
+                  wait-on: 'http://localhost:3000'
+                  wait-on-timeout: 300
+                  record: true
+                  parallel: true
+                  browser: chrome
+                  group: e2e-chrome-parallel-dev
+              env:
+                  BROWSER: none
+                  CYPRESS_RECORD_KEY: ${{ secrets.recordkey }}
+                  CYPRESS_dhis2BaseUrl: ${{ DEV_INSTANCE }}
+                  CYPRESS_dhis2InstanceVersion: ${{ needs.compute-dev-version.outputs.version }}
+                  CYPRESS_dhis2Username: ${{ secrets.username }}
+                  CYPRESS_dhis2Password: ${{ secrets.password }}
+                  CYPRESS_networkMode: live
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/analytics-e2e-tests-prod.yml
+++ b/.github/workflows/analytics-e2e-tests-prod.yml
@@ -16,8 +16,6 @@ name: 'e2e-prod'
 on:
     workflow_call:
         secrets:
-            baseurl:
-                required: true
             username:
                 required: true
             password:
@@ -32,9 +30,9 @@ on:
                 required: false
 
 env:
-    BASE_URL_INSTANCES: https://debug.dhis2.org
-    NAME_PATTERN_PROD_INSTANCES: '{version}'
-    NAME_PATTERN_DEV_INSTANCE: dev
+    BASE_URL_INSTANCES: https://test.e2e.dhis2.org
+    NAME_PATTERN_PROD_INSTANCES: 'analytics-{version}'
+    DEV_INSTANCE: https://test.e2e.dhis2.org/analytics-dev
 
 concurrency:
     group: e2e-prod-${{ github.workflow}}-${{ github.ref }}
@@ -45,25 +43,33 @@ defaults:
         shell: bash
 
 jobs:
+    compute-dev-version:
+        runs-on: ubuntu-latest
+        outputs:
+            version: ${{ steps.dev-version.outputs.version }}
+        steps:
+            - name: Output dev version
+              id: dev-version
+              uses: dhis2/action-instance-version@v1
+              with:
+                  instance-url: ${ DEV_INSTANCE }
+                  username: ${{ secrets.username }}
+                  password: ${{ secrets.password }}
+
     compute-prod-versions:
         runs-on: ubuntu-latest
+        needs: compute-dev-version
         outputs:
             versions: ${{ steps.prod-versions.outputs.versions }}
         steps:
-            - name: Compute dev instance url
-              id: instance-url
-              run: |
-                  url=${BASE_URL_INSTANCES%/}/${NAME_PATTERN_DEV_INSTANCE/"{version}"/dev}
-                  echo "url=$url" >> $GITHUB_OUTPUT
-                  echo "url: $url"
-
-            - uses: actions/checkout@v3
+            - name: Checkout
+              uses: actions/checkout@v3
 
             - name: Output prod version urls
               id: prod-versions
               uses: dhis2/action-supported-legacy-versions@v1
               with:
-                  instance-url-latest: ${{ steps.instance-url.outputs.url }} # can be removed if maxDHIS2Version has been specified
+                  instance-url-latest: ${{ needs.compute-dev-version.outputs.version }} # can be removed if maxDHIS2Version has been specified
                   username: ${{ secrets.username }}
                   password: ${{ secrets.password }}
 

--- a/.github/workflows/analytics-e2e-tests-prod.yml
+++ b/.github/workflows/analytics-e2e-tests-prod.yml
@@ -5,7 +5,6 @@ name: 'e2e-prod'
 # - Customize environment variables:
 #     BASE_URL_INSTANCES: Set the base url for the instances, e.g. https://test.e2e.dhis2.org
 #     NAME_PATTERN_PROD_INSTANCES: Set the name pattern for your instances. {version} will be replaced by "[majorVersion].[minorVersion]"
-#     NAME_PATTERN_DEV_INSTANCE: Set the name pattern for your dev instance. {version} will be replaced by "dev"
 #
 # - Other optional customizations:
 #     containers: Set the matrix containers array for the e2e-prod job. The number of parallel Cypress instances running for each backend version will equal the array length.
@@ -32,7 +31,6 @@ on:
 env:
     BASE_URL_INSTANCES: https://test.e2e.dhis2.org
     NAME_PATTERN_PROD_INSTANCES: 'analytics-{version}'
-    DEV_INSTANCE: https://test.e2e.dhis2.org/analytics-dev
 
 concurrency:
     group: e2e-prod-${{ github.workflow}}-${{ github.ref }}
@@ -52,7 +50,7 @@ jobs:
               id: dev-version
               uses: dhis2/action-instance-version@v1
               with:
-                  instance-url: ${ DEV_INSTANCE }
+                  instance-url: https://test.e2e.dhis2.org/analytics-dev
                   username: ${{ secrets.username }}
                   password: ${{ secrets.password }}
 

--- a/.github/workflows/analytics-e2e-tests-prod.yml
+++ b/.github/workflows/analytics-e2e-tests-prod.yml
@@ -41,22 +41,8 @@ defaults:
         shell: bash
 
 jobs:
-    compute-dev-version:
-        runs-on: ubuntu-latest
-        outputs:
-            version: ${{ steps.dev-version.outputs.version }}
-        steps:
-            - name: Output dev version
-              id: dev-version
-              uses: dhis2/action-instance-version@v1
-              with:
-                  instance-url: https://test.e2e.dhis2.org/analytics-dev
-                  username: ${{ secrets.username }}
-                  password: ${{ secrets.password }}
-
     compute-prod-versions:
         runs-on: ubuntu-latest
-        needs: compute-dev-version
         outputs:
             versions: ${{ steps.prod-versions.outputs.versions }}
         steps:
@@ -67,7 +53,7 @@ jobs:
               id: prod-versions
               uses: dhis2/action-supported-legacy-versions@v1
               with:
-                  instance-url-latest: ${{ needs.compute-dev-version.outputs.version }} # can be removed if maxDHIS2Version has been specified
+                  instance-url-latest: https://test.e2e.dhis2.org/analytics-dev # can be removed if maxDHIS2Version has been specified
                   username: ${{ secrets.username }}
                   password: ${{ secrets.password }}
 


### PR DESCRIPTION
Included in this PR:
- use test.e2e.dhis2.org as the base url for running tests
- add `analytics-e2e-tests-dev.yml` for running "nightly" tests against the dev (unreleased) instance
- use `dhis2/action-instance-version` to get the dev version

As soon as this is merged, then maps-app, data-visualizer, and line-list should all merge PRs to update their workflows to use the renamed file "analytics-e2e-tests-prod.yml"