### PR TITLE
chore: get DHIS2 core version

### DIFF
--- a/.github/workflows/analytics-e2e-tests-prod.yml
+++ b/.github/workflows/analytics-e2e-tests-prod.yml
@@ -64,6 +64,7 @@ jobs:
             CI_BUILD_ID: ${{ github.sha }}-${{ github.workflow }}-${{ github.event_name }}
             BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
             PR_TITLE: ${{ github.event.pull_request.title }}
+            DHIS2_VERSION: ${{ matrix.versions }}
         strategy:
             fail-fast: false
             matrix:


### PR DESCRIPTION
get DHIS2 core version as env variable to reportportal 
update analytics-e2e-tests workflow only